### PR TITLE
Add purchasable buff items to shop

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
             <button class="tablinks" onclick="openCat(event, 'char')">Characters</button>
             <button class="tablinks" onclick="openCat(event, 'equip')">Equipments</button>
             <button class="tablinks" onclick="openCat(event, 'art')">Artifacts</button>
+            <button class="tablinks" onclick="openCat(event, 'buffs')">Buffs</button>
           </div>
           <div id="char" class="tabcontent">
             <h3 style="box-shadow: none;">Coming soon</h3>
@@ -58,6 +59,14 @@
                 <a href="#"><img src="images/art4.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Necklace of Sloth - 290 Coins</h2><br>Increases Life Steal by 8%.</span></a>
                 <a href="#"><img src="images/art5.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Sword of Wrath - 410 Coins</h2><br>Increases Physical DMG by 6%.</span></a>
                 <a href="#"><img src="images/art6.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Staff of Greed - 320 Coins</h2><br>Increases Heal Effect by 10%.</span></a>
+                <br>
+            </ul>
+          </div>
+          <div id="buffs" class="tabcontent">
+            <h3 style="box-shadow: none; color:rgb(150, 219, 165)">Buff Items</h3>
+            <ul>
+                <a href="#" onclick="buyBuff('atk')"><img src="images/atkbuff.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Blessing of Fire - 100 Coins</h2><br>Increase ATK by 30% for this battle.</span></a>
+                <a href="#" onclick="buyBuff('def')"><img src="images/defbuff.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Blessing of Ice - 100 Coins</h2><br>Increase DEF by 30% for this battle.</span></a>
                 <br>
             </ul>
           </div>

--- a/script.js
+++ b/script.js
@@ -85,6 +85,9 @@ let hunterIcon = document.getElementById("huntericon");
 let hunterAtkIcon = document.getElementById("hunteratkicon");
 let playerDefText = document.getElementById("def");
 
+let atkBuffIcon = document.getElementById("atkbufficon");
+let defBuffIcon = document.getElementById("defbufficon");
+
 let playerCritText = document.getElementById("crit");
 let playerCritDMGText = document.getElementById("critdmg");
 let lightmarkicon = document.getElementById("lighticon");
@@ -149,6 +152,8 @@ let bleedTurnText = document.getElementById("bleedText");
 let hunteratkbuff = false;
 let hunteratkcooldown = 0;
 let hunteratkmodifier = 0;
+let attackBuff = false;
+let defenseBuff = false;
 let playerdefaultdef = 250;
 let playerDEF = playerdefaultdef;
 
@@ -551,6 +556,10 @@ statslvl = [1,1,1,1];
     document.getElementById("glow").style.display = "none";
    
     healBuffIcon.style.display = "none";
+    atkBuffIcon.style.display = "none";
+    defBuffIcon.style.display = "none";
+    attackBuff = false;
+    defenseBuff = false;
     hunterIcon.style.display = "none";
     hunterAtkIcon.style.display = "none";
     holyshieldicon.style.display = "none";
@@ -2089,7 +2098,41 @@ function openShop() {
 function closeShop() {
     document.getElementById("shop").style.display = "none";
     setTimeout(()=>{document.getElementById("shop").style.opacity = 0}, 200);
-    
+
+}
+
+function buyBuff(type) {
+    const cost = 100;
+    if (coin < cost) {
+        alert('Not enough coins!');
+        return;
+    }
+    switch (type) {
+        case 'atk':
+            if (attackBuff) {
+                alert('Attack buff already active!');
+                return;
+            }
+            coin -= cost;
+            playerATK += playerATK * 0.3;
+            playerAtkText.innerHTML = parseInt(playerATK);
+            atkBuffIcon.style.display = 'block';
+            attackBuff = true;
+            break;
+        case 'def':
+            if (defenseBuff) {
+                alert('Defense buff already active!');
+                return;
+            }
+            coin -= cost;
+            playerDEF += playerDEF * 0.3;
+            playerDefText.innerHTML = parseInt(playerDEF);
+            defBuffIcon.style.display = 'block';
+            defenseBuff = true;
+            break;
+    }
+    document.getElementById('coin').innerHTML = coin.toFixed(0);
+    document.getElementById('cointext').innerHTML = 'Available coins: ' + coin.toFixed(0);
 }
 
 


### PR DESCRIPTION
## Summary
- add Buffs tab to the shop with Blessing of Fire and Blessing of Ice items
- implement `buyBuff` to apply attack/defense bonuses and deduct coins
- reset purchased buff effects when restarting the game

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897407d29848329b56dd0d02186c88c