### PR TITLE
Broaden game view and overhaul text for fantasy setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,28 +37,18 @@
         <h5>Welcome to the shop! (WIP - not working at the moment)</h5>
         <h3 style="box-shadow: none;" id="cointext">Available coins: 0</h3><br>
         <div class="tab">
-            <button class="tablinks" onclick="openCat(event, 'char')">Characters</button>
-            <button class="tablinks" onclick="openCat(event, 'equip')">Equipments</button>
             <button class="tablinks" onclick="openCat(event, 'art')">Artifacts</button>
             <button class="tablinks" onclick="openCat(event, 'buffs')">Buffs</button>
           </div>
-          <div id="char" class="tabcontent">
-            <h3 style="box-shadow: none;">Coming soon</h3>
-            
-          </div>
-          <div id="equip" class="tabcontent">
-            <h3 style="box-shadow: none;">Coming soon</h3>
-            
-          </div>
           <div id="art" class="tabcontent">
-            <h3 style="box-shadow: none; color:rgb(150, 219, 165)">Level 1 Artifacts</h3>
+            <h3 style="box-shadow: none; color:rgb(150, 219, 165)">Level <span id="artifactLevel">1</span> Artifacts</h3>
             <ul>
-                <a href="#"><img src="images/art1.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Ring of Gluttony - 350 Coins</h2><br>Increases Elemental DMG by 6%.</span></a>
-                <a href="#"><img src="images/art2.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Bow of Envy - 450 Coins</h2><br>Increases Critical Rate by 10%.</span></a>
-                <a href="#"><img src="images/art3.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Helm of Pride - 360 Coins</h2><br>Decreases incoming DMG by 10%.</span></a>
-                <a href="#"><img src="images/art4.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Necklace of Sloth - 290 Coins</h2><br>Increases Life Steal by 8%.</span></a>
-                <a href="#"><img src="images/art5.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Sword of Wrath - 410 Coins</h2><br>Increases Physical DMG by 6%.</span></a>
-                <a href="#"><img src="images/art6.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Staff of Greed - 320 Coins</h2><br>Increases Heal Effect by 10%.</span></a>
+                <a href="#"><img src="images/art1.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Ring of Arcana - 350 Coins</h2><br>Increases Elemental DMG by <span id="gluttonyBuff">6</span>%.</span></a>
+                <a href="#"><img src="images/art2.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Sylvan Bow - 450 Coins</h2><br>Increases Critical Rate by <span id="envyBuff">10</span>%.</span></a>
+                <a href="#"><img src="images/art3.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Helm of Valor - 360 Coins</h2><br>Decreases incoming DMG by <span id="prideBuff">10</span>%.</span></a>
+                <a href="#"><img src="images/art4.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Amulet of Vitality - 290 Coins</h2><br>Increases Life Steal by <span id="slothBuff">8</span>%.</span></a>
+                <a href="#"><img src="images/art5.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Blade of Fury - 410 Coins</h2><br>Increases Physical DMG by <span id="wrathBuff">6</span>%.</span></a>
+                <a href="#"><img src="images/art6.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(32, 141, 56); font-size: 27px;">Staff of Plenty - 320 Coins</h2><br>Increases Heal Effect by <span id="greedBuff">10</span>%.</span></a>
                 <br>
             </ul>
           </div>
@@ -76,63 +66,63 @@
     <div id="settings">
         <ul id="ulsettings2">
             <h5>Change Your Character</h5>
-            <li><button id="mage" class="classchange" onclick="switchClass('mage')">Elemental Mage</button></li>
-            <li><button id="archer" class="classchange" onclick="switchClass('archer')">Mech Archer</button></li>
-            <li><button id="paladin" class="classchange" onclick="switchClass('paladin')">Paladin of Light</button></li>
+            <li><button id="mage" class="classchange" onclick="switchClass('mage')">Arcane Sorcerer</button></li>
+            <li><button id="archer" class="classchange" onclick="switchClass('archer')">Elven Ranger</button></li>
+            <li><button id="paladin" class="classchange" onclick="switchClass('paladin')">Holy Paladin</button></li>
             <li><button id="necromancer" class="classchange" onclick="switchClass('necromancer')">Necromancer</button></li><br><br>
-            <li><button id="knight" class="classchange" onclick="switchClass('knight')">Blood Knight</button></li>
-            <li><button id="swordsinger" class="classchange" onclick="switchClass('swordsinger')">Divine Swordsinger</button></li>
-            <li><button id="cryomancer" class="classchange" onclick="switchClass('cryomancer')">Cryomancy Empress</button></li>
+            <li><button id="knight" class="classchange" onclick="switchClass('knight')">Crimson Knight</button></li>
+            <li><button id="swordsinger" class="classchange" onclick="switchClass('swordsinger')">Celestial Swordsinger</button></li>
+            <li><button id="cryomancer" class="classchange" onclick="switchClass('cryomancer')">Frost Empress</button></li>
         </ul>
         <br><br><br><br><br><br><br><br><br>
         <ul id="ulsettings">
 
-        <li><button id="mage" class="classchange">Elemental Mage</button></li>
+        <li><button id="mage" class="classchange">Arcane Sorcerer</button></li>
         <li><button id="mage" class="classchange" style="margin-left: -25px; width: 130px; font-size: 12px; background-color: #fff; color:rgb(161, 45, 152);">Elemental DMG</button></li><br>
         
         <li>
             <h2 style="font-size: 15px; background-color: #ffffff00; border: 0px;">
             <img src="images/elementalmage.png" style="width: 60px;">
-            <a href="#"><img src="images/s1.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Icebolt- Basic Attack</h2><br>Deals <span class="elemental">110% DMG (+250)</span> to the target and restore 20~25 energy.</span></a>
-            <a href="#"><img src="images/s2.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Rain of Fire - 30</h2><br>Deals <span class="elemental">150% DMG (+450)</span> to the target and makes it receive 30% more DMG for any subsequent direct attack.</span></a>
-            <a href="#"><img src="images/s3.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Thunderstorm - 60</h2><br>Deals <span class="elemental">510% DMG (+1950)</span> to the target. With Bane of Death, this skill's DMG is increased by 60%. Also, increases the amount of healing by 50% for the next heal skill.</span></a>
-            <a href="#"><img src="images/s4.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Bane of Death - 40</h2><br>Deals <span class="elemental">150% DMG (+150)</span> and another 120% DMG to the target every turn for 3 turns.</span></a>
-            <a href="#"><img src="images/p1.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Arcane Erudition - Passive</h2><br>While Bane of Death effect is active, reduces the target's DEF by 35%.</span></a>
+            <a href="#"><img src="images/s1.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Frost Bolt - Basic Attack</h2><br>Deals <span class="elemental">110% DMG (+250)</span> to the target and restore 20~25 energy.</span></a>
+            <a href="#"><img src="images/s2.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Flamestrike - 30</h2><br>Deals <span class="elemental">150% DMG (+450)</span> to the target and makes it receive 30% more DMG for any subsequent direct attack.</span></a>
+            <a href="#"><img src="images/s3.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Arcane Tempest - 60</h2><br>Deals <span class="elemental">510% DMG (+1950)</span> to the target. With Curse of Decay, this skill's DMG is increased by 60%. Also, increases the amount of healing by 50% for the next heal skill.</span></a>
+            <a href="#"><img src="images/s4.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Curse of Decay - 40</h2><br>Deals <span class="elemental">150% DMG (+150)</span> and another 120% DMG to the target every turn for 3 turns.</span></a>
+            <a href="#"><img src="images/p1.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Arcane Erudition - Passive</h2><br>While Curse of Decay effect is active, reduces the target's DEF by 35%.</span></a>
             <img src="images/elementalmage.png" style="width: 60px; transform: scaleX(-1);">
             </h2>
         </li><br>
-        <li><h2 style="font-size: 15px; color:royalblue; width: 650px; margin: auto; margin-top: 10px;">The Elemental Mage is a versatile spellcaster who has mastered the elements of fire, ice, poison, and thunder. With an arsenal of devastating spells at their fingertips, they can easily control the battlefield to their advantage. But don't be intimidated by their power, as the Elemental Mage is also very beginner-friendly. They have a well-balanced playstyle, with both offensive and defensive mechanics that make them a reliable and adaptable option for any situation. Whether you're looking to unleash fiery explosions, the Elemental Mage has got you covered.</h2></li><br>
+        <li><h2 style="font-size: 15px; color:royalblue; width: 650px; margin: auto; margin-top: 10px;">The Arcane Sorcerer is a versatile spellcaster who has mastered the elements of fire, ice, poison, and thunder. With an arsenal of devastating spells at their fingertips, they can easily control the battlefield to their advantage. Despite their overwhelming power, the Arcane Sorcerer remains approachable to new adventurers. With a well-balanced playstyle that blends offense and defense, this mage is a reliable and adaptable option for any quest.</h2></li><br>
         
         <br><hr><br>
-        <li><button id="archer" class="classchange">Mech Archer</button></li>
+        <li><button id="archer" class="classchange">Elven Ranger</button></li>
         <li><button id="mage" class="classchange" style="margin-left: -25px; width: 130px; font-size: 12px; background-color: #fff; color:rgb(190, 104, 47);">Physical DMG</button></li><br>
         <li>
             <h2 style="font-size: 15px; background-color: #ffffff00; border: 0px;">
                 <img src="images/archer.png" style="width: 60px;">    
-            <a href="#"><img src="images/s5.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Arrow of Light- Basic Attack</h2><br>Deals <span class="physical">100% DMG (+200)</span> to the target. Marks it with a Hunter's Mark. Restores 10~20 energy.</span></a>
-            <a href="#"><img src="images/s6.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Bloodshed - 30</h2><br>Deals <span class="physical">200% DMG (+470)</span> to the target and another 125% DMG to the target every turn for 3 turns.</span></a>
+            <a href="#"><img src="images/s5.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Radiant Arrow - Basic Attack</h2><br>Deals <span class="physical">100% DMG (+200)</span> to the target. Marks it with a Hunter's Mark. Restores 10~20 energy.</span></a>
+            <a href="#"><img src="images/s6.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Crimson Volley - 30</h2><br>Deals <span class="physical">200% DMG (+470)</span> to the target and another 125% DMG to the target every turn for 3 turns.</span></a>
             <a href="#"><img src="images/s7.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Piercing Shot - 60</h2><br>Deals <span class="physical">480% DMG (+1750)</span> to the target. If the target is under Hunter's Mark, removes the mark and deals an additional amount of 250% DMG. Also, if the target is under Bleed, this skill's DMG is increased by 50%.</span></a>
             <a href="#"><img src="images/s8.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Hunter's Instinct - 40</h2><br>Increases Critical DMG by 120% for 3 turns and Critical Rate until the next Crit Hit by 30% and mark the enemy with Hunter's Mark.</span></a>
             <a href="#"><img src="images/p2.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Forest's Favor - Passive</h2><br>After Hunter's Mark is removed, heals self by 50% of Max HP.</span></a>
             <img src="images/archer.png" style="width: 60px; transform: scaleX(-1);">
         </h2>
         </li><br>
-        <li><h2 style="font-size: 15px; color:rgb(99, 139, 46); width: 650px; margin: auto; margin-top: 10px;">Meet the Mech Archer, a once elegant elf archer who has now been augmented into a powerful mechanical warrior. Armed with a futuristic bow, this skilled marksman excels at applying bleeding damage to her targets, leaving them struggling to stay on their feet. The Mech Archer also possesses the Hunter's Mark ability, allowing her to track and strike her prey with pinpoint accuracy. However, with her focus on pure offense, this mechanized elf has little in the way of defensive abilities, making her a high-risk, high-reward choice for any daring player. Are you ready to take aim and bring the pain with the Mech Archer?</h2></li><br>
+        <li><h2 style="font-size: 15px; color:rgb(99, 139, 46); width: 650px; margin: auto; margin-top: 10px;">The Elven Ranger is a swift hunter from the ancient woods. Armed with a finely crafted bow, she excels at striking vital points and leaving foes bleeding from precise volleys. Though lightly armored, the ranger's mastery of the Hunter's Mark lets her track and eliminate prey with uncanny accuracy.</h2></li><br>
         <br><hr><br>
-        <li><button id="paladin" class="classchange">Paladin of Light</button></li>
+        <li><button id="paladin" class="classchange">Holy Paladin</button></li>
         <li><button id="mage" class="classchange" style="margin-left: -25px; width: 130px; font-size: 12px; background-color: #fff; color:rgb(190, 104, 47);">Physical DMG</button></li><br>
          <li>
             <h2 style="font-size: 15px; background-color: #ffffff00; border: 0px;">
                 <img src="images/paladin.png" style="width: 60px;">
-            <a href="#"><img src="images/s9.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Righteousness- Basic Attack</h2><br>Deals <span class="physical">120% DMG (+240)</span> to the target and decreases its ATK by 20% for 2 turns and mark it with a Light mark. Restores 10~20 energy.</span></a>
-            <a href="#"><img src="images/s10.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Rectitude - 30</h2><br>Deals <span class="physical">140% DMG (+300)</span> to the target and marks it with a Light mark. Also, increases self DEF by 30% for 2 turns.</span></a>
-            <a href="#"><img src="images/s11.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Judgment - 60</h2><br>Deals <span class="physical">330% DMG (+1315)</span> to the target. For each Light mark on the target, deals an additional 100% of DEF as DMG and removes all Light marks.</span></a>
-            <a href="#"><img src="images/s12.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Honor - 40</h2><br>Deals <span class="physical">160% DMG (+500)</span> and another 250% of DEF as DMG if more than 5 Light Marks are present. After use, removes 2 Light Marks. After that, grants a shield of 50% of his Max HP.</span></a>
+            <a href="#"><img src="images/s9.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Righteous Strike - Basic Attack</h2><br>Deals <span class="physical">120% DMG (+240)</span> to the target and decreases its ATK by 20% for 2 turns and mark it with a Light mark. Restores 10~20 energy.</span></a>
+            <a href="#"><img src="images/s10.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Shield of Faith - 30</h2><br>Deals <span class="physical">140% DMG (+300)</span> to the target and marks it with a Light mark. Also, increases self DEF by 30% for 2 turns.</span></a>
+            <a href="#"><img src="images/s11.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Divine Judgment - 60</h2><br>Deals <span class="physical">330% DMG (+1315)</span> to the target. For each Light mark on the target, deals an additional 100% of DEF as DMG and removes all Light marks.</span></a>
+            <a href="#"><img src="images/s12.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Sacred Oath - 40</h2><br>Deals <span class="physical">160% DMG (+500)</span> and another 250% of DEF as DMG if more than 5 Light Marks are present. After use, removes 2 Light Marks. After that, grants a shield of 50% of his Max HP.</span></a>
             <a href="#"><img src="images/p3.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Grace - Passive</h2><br>Each Lightmark removed restores 5~10 Energy.</span></a>
             <img src="images/paladin.png" style="width: 60px;">
             </h2>
         </li><br>
-        <li><h2 style="font-size: 15px; color:rgb(139, 106, 46); width: 650px; margin: auto; margin-top: 10px;">The Paladin of Light is the embodiment of righteousness and unwavering faith. With a shield in one hand and a sword in the other, this holy warrior is a force to be reckoned with. The Paladin excels at defending against enemy attacks and has decent damage output to boot. With straightforward mechanics, the Paladin is easy to pick up and play, making it a great choice for beginners. So, if you're looking for a straightforward and dependable hero, the Paladin of Light may be just what you need.</h2></li><br>
+        <li><h2 style="font-size: 15px; color:rgb(139, 106, 46); width: 650px; margin: auto; margin-top: 10px;">The Holy Paladin is the embodiment of righteousness and unwavering faith. With a shield in one hand and a sword in the other, this holy warrior stands as a bulwark against darkness. The Paladin excels at defending against enemy attacks and has decent damage output to boot. Straightforward mechanics make the Holy Paladin a great choice for beginners seeking a dependable hero.</h2></li><br>
         
         <br><hr><br>
         <li><button id="necromancer" class="classchange">Necromancer</button></li>
@@ -150,28 +140,28 @@
         </li><br>
         <li><h2 style="font-size: 15px; color:rgb(131, 46, 139); width: 650px; margin: auto; margin-top: 10px;">The Necromancer, a master of the dark arts, commands the power of death itself. Through the use of forbidden spells and ancient rituals, this mysterious and feared mage can harness the very essence of life and death to their will. With their unique ability to apply two marks to their targets, the Necromancer can draw upon the life force of their enemies to both heal themselves and unleash devastating attacks. With each mark applied, the Necromancer's power grows, making them a formidable force to be reckoned with on the battlefield. But beware, for the price of wielding such power is steep, and the Necromancer must be careful not to fall prey to the very forces they seek to control.</h2></li><br>
         <br><hr><br>
-        <li><button id="knight" class="classchange">Blood Knight</button></li>
+        <li><button id="knight" class="classchange">Crimson Knight</button></li>
         <li><button id="mage" class="classchange" style="margin-left: -25px; width: 130px; font-size: 12px; background-color: #fff; color:rgb(190, 104, 47);">Physical DMG</button></li><br>
         <li>
             <h2 style="font-size: 15px; background-color: #ffffff00; border: 0px;">
                 <img src="images/bloodknight.png" style="width: 60px;">
-            <a href="#"><img src="images/s17.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Blood Embrace- Basic Attack</h2><br>Deals <span class="physical">120% DMG (+310)</span> to the target. If his HP is less than 50%, gain 1 Blood Sigil. Restores 10~13 Energy.</span></a>
-            <a href="#"><img src="images/s18.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Rosemary's Gift - 30</h2><br>Deals <span class="physical">160% DMG (+670)</span> to the target. Deals an additional amount of 10% of his loss HP as DMG. Gain 2 Blood Sigils.</span></a>
-            <a href="#"><img src="images/s19.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Ichor Retaliation - 70</h2><br>Deals <span class="physical">350% DMG (+1200)</span> to the target. For each Blood Sigil, deals an additional of 25% DMG and 2% of Max HP. Removes all Blood Sigils after that. For each removed Blood Sigil, grants a shield of 2% of his Max HP.</span></a>
+            <a href="#"><img src="images/s17.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Crimson Embrace - Basic Attack</h2><br>Deals <span class="physical">120% DMG (+310)</span> to the target. If his HP is less than 50%, gain 1 Blood Sigil. Restores 10~13 Energy.</span></a>
+            <a href="#"><img src="images/s18.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Vampiric Gift - 30</h2><br>Deals <span class="physical">160% DMG (+670)</span> to the target. Deals an additional amount of 10% of his loss HP as DMG. Gain 2 Blood Sigils.</span></a>
+            <a href="#"><img src="images/s19.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Ichor Reprisal - 70</h2><br>Deals <span class="physical">350% DMG (+1200)</span> to the target. For each Blood Sigil, deals an additional of 25% DMG and 2% of Max HP. Removes all Blood Sigils after that. For each removed Blood Sigil, grants a shield of 2% of his Max HP.</span></a>
             <a href="#"><img src="images/s20.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Crimson Vitality - 60</h2><br>Increases his Max HP by 30% for 3 turns. Also, grants a shield of 30% of his lost HP.</span></a>
             <a href="#"><img src="images/p5.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Hardened Will - Passive</h2><br>Each Blood Sigil will decrease his incoming DMG by 2% (up to 20%) and increases his DMG by 3% (up to 30%).</span></a>
             <img src="images/bloodknight.png" style="width: 60px;">
         </h2>
         </li><br>
-        <li><h2 style="font-size: 15px; color:rgb(139, 46, 46); width: 650px; margin: auto; margin-top: 10px;">The Blood Knight is a warrior who thrives on danger and relishes the thrill of battle. This fearless fighter wields a sword with deadly precision and is always ready to spill blood for the glory of combat. As the Blood Knight takes damage and loses health, his attacks grow stronger, allowing him to unleash devastating strikes that can turn the tide of any battle. With their unparalleled ferocity and unshakable resolve, the Blood Knight challenges even players with skills.</h2></li>
+        <li><h2 style="font-size: 15px; color:rgb(139, 46, 46); width: 650px; margin: auto; margin-top: 10px;">The Crimson Knight is a warrior who thrives on danger and relishes the thrill of battle. This fearless fighter wields a sword with deadly precision and is always ready to spill blood for the glory of combat. As the knight takes damage and loses health, his attacks grow stronger, allowing him to unleash devastating strikes that can turn the tide of any battle. With unparalleled ferocity and unshakable resolve, the Crimson Knight challenges even the most skilled adventurers.</h2></li>
         <br><br><hr><br>
-        <li><button id="swordsinger" class="classchange">Divine Swordsinger</button></li>
+        <li><button id="swordsinger" class="classchange">Celestial Swordsinger</button></li>
         <li><button id="mage" class="classchange" style="margin-left: -25px; width: 130px; font-size: 12px; background-color: #fff; color:rgb(161, 45, 152);">Elemental DMG</button></li>
         <li><button class="classchange flamecaller" style="margin-left: -25px; width: 90px; font-size: 12px; background-color: #ffaa32; color:rgb(120, 38, 27);">Legendary</button></li><br>
         <li>
             <h2 style="font-size: 15px; background-color: #ffffff00; border: 0px;">
                 <img src="images/swordsinger.png" style="width: 60px;">
-            <a href="#"><img src="images/s21.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(197, 109, 26); font-size: 27px;">Sacred Anthems- Basic Attack</h2><br>Deals <span class="elemental">100% DMG (+230)</span> to the target. Applies 2 random Holy Debuffs from this list:<br>- Purity: decreases ATK by 4%.<br>- Justice: decreases DEF by 4%.<br>- Faith: increases incoming DMG by 2%.<br>Each debuff can stack up to 10 times. Also restores 15 Energy.</span></a>
+            <a href="#"><img src="images/s21.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(197, 109, 26); font-size: 27px;">Sacred Anthem - Basic Attack</h2><br>Deals <span class="elemental">100% DMG (+230)</span> to the target. Applies 2 random Holy Debuffs from this list:<br>- Purity: decreases ATK by 4%.<br>- Justice: decreases DEF by 4%.<br>- Faith: increases incoming DMG by 2%.<br>Each debuff can stack up to 10 times. Also restores 15 Energy.</span></a>
             <a href="#"><img src="images/s22.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(197, 109, 26); font-size: 27px;">Revered Presence - 40</h2><br>Heals for 3040% of ATK + 30% of lost HP. Over-healed amount will be converted into Holy Shield.</span></a>
             <a href="#"><img src="images/s23.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(197, 109, 26); font-size: 27px;">Holy Chant - 80</h2><br>Deals <span class="elemental">400% DMG (+1515)</span> to the target and removes all debuffs. For each removed debuff, deals an additional of 100% DMG.</span></a>
             <a href="#"><img src="images/s24.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(197, 109, 26); font-size: 27px;">Transcendent Hymn - 50</h2><br>Stuns the target for 2 turns and after that, provides a Reflect buff that reflects 50% of received DMG for 3 turns.</span></a>
@@ -179,23 +169,23 @@
             <img src="images/swordsinger.png" style="width: 60px;">
         </h2>
         </li><br>
-        <li><h2 style="font-size: 15px; color:rgb(197, 109, 26); width: 650px; margin: auto; margin-top: 10px;">The Divine Swordsinger, a warrior whose voice echoes with the divine power of the gods themselves. Armed with a melody and a weapon that doubles as an instrument, she is a force to be reckoned with on the battlefield. Her songs can heal and strengthen herself, while also weakening and disrupting her foes. Her divine echoes strikes with precision, dealing devastating damage to those who stand in her way. In the hands of a skilled player, the Divine Swordsinger can turn the tide of any battle, singing her way to victory.</h2></li>
+        <li><h2 style="font-size: 15px; color:rgb(197, 109, 26); width: 650px; margin: auto; margin-top: 10px;">The Celestial Swordsinger is a warrior whose voice echoes with the power of the heavens. Armed with a melody and a weapon that doubles as an instrument, she is a force to be reckoned with on the battlefield. Her songs can heal and strengthen herself while weakening and disrupting her foes. In the hands of a skilled player, the Celestial Swordsinger can turn the tide of any battle, singing her way to victory.</h2></li>
         <br><br><hr><br>
-        <li><button id="cryomancer" class="classchange">Cryomancy Empress</button></li>
+        <li><button id="cryomancer" class="classchange">Frost Empress</button></li>
         <li><button id="cryomancer" class="classchange" style="margin-left: -25px; width: 130px; font-size: 12px; background-color: #fff; color:rgb(161, 45, 152);">Elemental DMG</button></li>
         <li><button class="classchange flamecaller" style="margin-left: -25px; width: 90px; font-size: 12px; background-color: #ffaa32; color:rgb(120, 38, 27);">Legendary</button></li><br>
         <li>
             <h2 style="font-size: 15px; background-color: #ffffff00; border: 0px;">
                 <img src="images/cryomancer.png" style="width: 60px;">
-            <a href="#"><img src="images/s29.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Frosty Crown- Basic Attack</h2><br>Deals <span class="elemental">120% DMG (+310)</span> to the target. Applies 1 Frost debuff. Each Frost Debuff increases target's Incoming DMG by 10%, stacks 3 times. Also, restores 15 Energy.</span></a>
-            <a href="#"><img src="images/s30.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Frigid Mind- 40</h2><br>Deals <span class="elemental">220% DMG (+570)</span> to the target. For each Frost debuff, applies Frozen state to the target for 1 turn. In Frozen state, the target cannot act.</span></a>
+            <a href="#"><img src="images/s29.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Frost Crown - Basic Attack</h2><br>Deals <span class="elemental">120% DMG (+310)</span> to the target. Applies 1 Frost debuff. Each Frost Debuff increases target's Incoming DMG by 10%, stacks 3 times. Also, restores 15 Energy.</span></a>
+            <a href="#"><img src="images/s30.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Frozen Mind - 40</h2><br>Deals <span class="elemental">220% DMG (+570)</span> to the target. For each Frost debuff, applies Frozen state to the target for 1 turn. In Frozen state, the target cannot act.</span></a>
             <a href="#"><img src="images/s31.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Icy Heart - 80</h2><br>Deals <span class="elemental">230% DMG (+1800)</span> to the target. If the target is Frozen, removes Frozen state and all Frost debuffs and increases this skill's DMG by 40% for each removed debuff.</span></a>
             <a href="#"><img src="images/s32.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Glacial Aura - 40</h2><br>Gives a shield of 50% of her Max HP and heal herself of 30% of Max HP. Under the shield, she takes 30% less DMG and deals 20% more DMG.</span></a>
             <a href="#"><img src="images/p7.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Everwinter Gaze - Passive</h2><br>DMG dealt to targets under Frozen state is increases by 40%.</span></a>
             <img src="images/cryomancer.png" style="width: 60px; transform: scale(-1);">
         </h2>
         </li><br>
-        <li><h2 style="font-size: 15px; color:rgb(27, 159, 168); width: 650px; margin: auto; margin-top: 10px;">As the ruler of the frozen kingdom, the Cryomancy Empress holds the power to command the elements of ice and snow. Her mastery over these elements grants her unparalleled control over the battlefield, freezing her enemies in their tracks with icy blasts and snowstorms. Yet, it is not just her control that makes her a force to be reckoned with. The Empress is also a fearsome combatant, wielding her powers with deadly precision to strike down those who dare to oppose her. With her icy grip on the battlefield and her icy heart, the Cryomancy Empress is a formidable presence on the battlefield.</h2></li>
+        <li><h2 style="font-size: 15px; color:rgb(27, 159, 168); width: 650px; margin: auto; margin-top: 10px;">As the ruler of the frozen kingdom, the Frost Empress holds the power to command the elements of ice and snow. Her mastery over these elements grants her unparalleled control over the battlefield, freezing her enemies in their tracks with icy blasts and snowstorms. With her icy grip on the battlefield and her frozen heart, the Frost Empress is a formidable presence to behold.</h2></li>
         <br><br><hr><br>
         <li><button class="classchange flamecaller">Fiery Flamecaller</button></li>
         <li><button class="classchange flamecaller" style="margin-left: -25px; width: 130px; font-size: 12px; background-color: #fff; color:rgb(161, 45, 152);">Elemental DMG</button></li>
@@ -227,13 +217,13 @@
             Good luck! <br>
             </p>
             <ul id="ulsettings">
-                <li><button id="mage2" class="classchange" onclick="switchClass('mage')">Elemental Mage</button></li>
-                <li><button id="archer2" class="classchange" onclick="switchClass('archer')">Mech Archer</button></li>
-                <li><button id="paladin2" class="classchange" onclick="switchClass('paladin')">Paladin of Light</button></li>
+                <li><button id="mage2" class="classchange" onclick="switchClass('mage')">Arcane Sorcerer</button></li>
+                <li><button id="archer2" class="classchange" onclick="switchClass('archer')">Elven Ranger</button></li>
+                <li><button id="paladin2" class="classchange" onclick="switchClass('paladin')">Holy Paladin</button></li>
                 <li><button id="necromancer2" class="classchange" onclick="switchClass('necromancer')">Necromancer</button></li><br><br>
-                <li><button id="knight2" class="classchange" onclick="switchClass('knight')">Blood Knight</button></li>
-                <li><button id="swordsinger2" class="classchange" onclick="switchClass('swordsinger')">Divine Swordsinger</button></li><br><br><hr><br>
-                <li><button id="cryomancer2" class="classchange" onclick="switchClass('cryomancer')">Cryomancy Empress</button></li>
+                <li><button id="knight2" class="classchange" onclick="switchClass('knight')">Crimson Knight</button></li>
+                <li><button id="swordsinger2" class="classchange" onclick="switchClass('swordsinger')">Celestial Swordsinger</button></li><br><br><hr><br>
+                <li><button id="cryomancer2" class="classchange" onclick="switchClass('cryomancer')">Frost Empress</button></li>
                 </ul> 
                 
                 
@@ -279,11 +269,11 @@
             <div id="imgcontainer">
                 <a href="#" id="atkdebufficon"><img src="images/atkdebuff.png" class="icon"><span class="tooltip"><h2 class="flavortextminus">Curse of Power</h2><br>The Dragon's ATK is decreased by 30%.</span></a>
                 <a href="#" id="dmgreceiveicon"><img src="images/dmgreceive.png" class="icon"><span class="tooltip"><h2 class="flavortextminus">Curse of Weakness</h2><br>The Dragon receives 30% more DMG for the next attack.</span></a>
-                <a href="#" id="poisonicon"><img src="images/s4.png" class="icon"><span class="tooltip"><h2 class="flavortextminus">Bane of Death</h2><br>Deals DoT DMG of 120% per turn for 3 turns.<br><br><p id="poisonText">0 turns left.</p></span></a>
-                <a href="#" id="bleedicon"><img src="images/s6.png" class="icon"><span class="tooltip"><h2 class="flavortextminus">Bloodshed</h2><br>Deals DoT DMG of 125% per turn for 3 turns.<br><br><p id="bleedText">0 turns left.</p></span></a>
                 <a href="#" id="huntericon"><img src="images/hunter.png" class="icon"><span class="tooltip"><h2 class="flavortextminus">Hunter's Mark</h2><br>You cannot escape the eye of a hunter.</span></a>
                 <a href="#" id="lighticon"><p id="lightnumber" style="position: absolute; left: 3px; top: 1px;">0</p><img src="images/light.png" class="icon"><span class="tooltip"><h2 class="flavortextminus">Light Mark</h2><br>You shall be judged.<br><br><p id="lightText">0 stacks.</p></span></a>
-                <a href="#" id="lightatkdebufficon"><img src="images/s9.png" class="icon"><span class="tooltip"><h2 class="flavortextminus">Righteousness</h2><br>Decreases ATK by 20%.</span></a>
+                <a href="#" id="poisonicon"><img src="images/s4.png" class="icon"><span class="tooltip"><h2 class="flavortextminus">Curse of Decay</h2><br>Deals DoT DMG of 120% per turn for 3 turns.<br><br><p id="poisonText">0 turns left.</p></span></a>
+                <a href="#" id="bleedicon"><img src="images/s6.png" class="icon"><span class="tooltip"><h2 class="flavortextminus">Crimson Volley</h2><br>Deals DoT DMG of 125% per turn for 3 turns.<br><br><p id="bleedText">0 turns left.</p></span></a>
+                <a href="#" id="lightatkdebufficon"><img src="images/s9.png" class="icon"><span class="tooltip"><h2 class="flavortextminus">Righteous Strike</h2><br>Decreases ATK by 20%.</span></a>
                 <a href="#" id="soulsiphonicon"><img src="images/s13.png" class="icon"><span class="tooltip"><h2 class="flavortextminus">Soul Siphon</h2><br>Your soul is mine.</span></a>
                 <a href="#" id="mindgleaningicon"><img src="images/s14.png" class="icon"><span class="tooltip"><h2 class="flavortextminus">Mind Gleaning</h2><br>Your mind is also mine.</span></a>
                 <a href="#" id="d1icon"><p id="d1number" style="position: absolute; left: 3px; top: 1px;">0</p><img src="images/d1icon.png" class="icon"><span class="tooltip"><h2 class="flavortextminus">Purity</h2><br>Decreases ATK by 4%.</span></a>
@@ -323,7 +313,7 @@
             <a href="#" id="holyshieldicon"><img src="images/holyshield.png" class="icon"><span class="tooltip"><h3 class="flavortextplus">Heaven's Will</h3><br>A shield to protect yourself from harm.</span></a>
             <a href="#" id="doubledmgicon"><img src="images/doubledmg.png" class="icon"><span class="tooltip"><h3 class="flavortextplus">Edge of Eternity</h3><br>Doubles the next direct DMG.</span></a>
             <a href="#" id="hunteratkicon"><img src="images/s8.png" class="icon"><span class="tooltip"><h3 class="flavortextplus">Hunter's Instinct</h3><br>Increases Critical DMG by 120% and Critical Rate by 30% for 2 turns.</span></a>
-            <a href="#" id="lightdefbufficon"><img src="images/s10.png" class="icon"><span class="tooltip"><h3 class="flavortextplus">Rectitude</h3><br>Increases DEF by 30% for 2 turns.</span></a>
+            <a href="#" id="lightdefbufficon"><img src="images/s10.png" class="icon"><span class="tooltip"><h3 class="flavortextplus">Shield of Faith</h3><br>Increases DEF by 30% for 2 turns.</span></a>
             <a href="#" id="moonicon"><img src="images/moon.png" class="icon"><span class="tooltip"><h3 class="flavortextplus">Song of Moonlight</h3><br>Increases ATK by 50% for 2 turns.</span></a>
             <a href="#" id="bloodsigilicon"><p id="sigilnumber" style="position: absolute; left: 3px; top: 1px;">0</p><img src="images/bloodsigil.png" class="icon"><span class="tooltip"><h3 class="flavortextplus">Blood Sigil</h3><br>Oath of Blood shall be fulfilled.<br><br><p id="bloodsigilText">0 stacks.</p></span></a>
             <a href="#" id="crimsonicon"><img src="images/crimson.png" class="icon"><span class="tooltip"><h3 class="flavortextplus">Crimson Vitality</h3><br>Increases Max HP by 50% for 3 turns.</span></a>
@@ -336,7 +326,7 @@
             <li><input type="text" id="magicField" placeholder="Enter a command here!"></input></li><br><br>
             <li><progress id="playerHealth" value="10000" max="10000"></progress></li><br>
             <li><progress id="holyshieldbar" value="0" max="20000"></progress></li><br>
-            <li><button class="classchange" id="mageclass" style="width: 276px; height: 45px; font-size: 24px;">Elemental Mage</button></li>
+            <li><button class="classchange" id="mageclass" style="width: 276px; height: 45px; font-size: 24px;">Arcane Sorcerer</button></li>
             <li><button class="support" id="playerLvl" style="width: 150px; height: 45px; font-size: 24px;">Level 1</button></li><br><br>
             
             <li><button class="support" id="hpbutton">HP: <p id="hp">0</p>/<p id="maxhp">0</p></button></li>
@@ -364,17 +354,17 @@
             <ul id="skillactive">
                
                 <img src="images/elementalmage.png" style="width: 60px;">
-                <a href="#"><img src="images/s1.png" class="icon" id="n1"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Icebolt- Basic Attack</h2><br>Deals 110% DMG (+250) to the target and restore 20~25 energy.</span></a>
-                <a href="#"><img src="images/s2.png" class="icon" id="a1"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Rain of Fire - 30 - CD: 2 turns</h2><br>Deals 150% DMG (+450) to the target and makes it receive 30% more DMG for any subsequent direct attack.</span></a>
-                <a href="#"><img src="images/s3.png" class="icon" id="a2"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Thunderstorm - 60 - CD: 3 turns</h2><br>Deals 510% DMG (+1950) to the target. With Bane of Death, this skill's DMG is increased by 60%. Also, increases the amount of healing by 50% for the next heal skill.</span></a>
-                <a href="#"><img src="images/s4.png" class="icon" id="a3"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Bane of Death - 40 - CD: 2 turns</h2><br>Deals 150% DMG (+150) and another 120% DMG to the target every turn for 3 turns.</span></a>
-                <a href="#"><img src="images/p1.png" class="icon"><span class="tooltip" id="p1"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Arcane Erudition - Passive</h2><br>While Bane of Death effect is active, reduces the target's DEF by 35%.</span></a>
+                <a href="#"><img src="images/s1.png" class="icon" id="n1"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Frost Bolt - Basic Attack</h2><br>Deals 110% DMG (+250) to the target and restore 20~25 energy.</span></a>
+                <a href="#"><img src="images/s2.png" class="icon" id="a1"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Flamestrike - 30 - CD: 2 turns</h2><br>Deals 150% DMG (+450) to the target and makes it receive 30% more DMG for any subsequent direct attack.</span></a>
+                <a href="#"><img src="images/s3.png" class="icon" id="a2"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Arcane Tempest - 60 - CD: 3 turns</h2><br>Deals 510% DMG (+1950) to the target. With Curse of Decay, this skill's DMG is increased by 60%. Also, increases the amount of healing by 50% for the next heal skill.</span></a>
+                <a href="#"><img src="images/s4.png" class="icon" id="a3"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Curse of Decay - 40 - CD: 2 turns</h2><br>Deals 150% DMG (+150) and another 120% DMG to the target every turn for 3 turns.</span></a>
+                <a href="#"><img src="images/p1.png" class="icon"><span class="tooltip" id="p1"><h2 class="flavortextminus" style="color: rgb(89, 131, 255); font-size: 27px;">Arcane Erudition - Passive</h2><br>While Curse of Decay effect is active, reduces the target's DEF by 35%.</span></a>
                 <img src="images/elementalmage.png" style="width: 60px; transform: scaleX(-1);">
             </ul>
             <ul id="skillactive2">
                 <img src="images/archer.png" style="width: 60px;">   
-                <a href="#"><img src="images/s5.png" class="icon" id="n2"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Arrow of Light- Basic Attack</h2><br>Deals 100% DMG (+200) to the target. Marks it with a Hunter's Mark. Restores 10~20 energy.</span></a>
-            <a href="#"><img src="images/s6.png" class="icon" id="a4"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Bloodshed - 30 - CD: 2 turns</h2><br>Deals 200% DMG (+470) to the target and another 125% DMG to the target every turn for 3 turns.</span></a>
+                <a href="#"><img src="images/s5.png" class="icon" id="n2"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Radiant Arrow- Basic Attack</h2><br>Deals 100% DMG (+200) to the target. Marks it with a Hunter's Mark. Restores 10~20 energy.</span></a>
+            <a href="#"><img src="images/s6.png" class="icon" id="a4"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Crimson Volley - 30 - CD: 2 turns</h2><br>Deals 200% DMG (+470) to the target and another 125% DMG to the target every turn for 3 turns.</span></a>
             <a href="#"><img src="images/s7.png" class="icon" id="a5"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Piercing Shot - 60 - CD: 2 turns</h2><br>Deals 480% DMG (+1750) to the target. If the target is under Hunter's Mark, removes the mark and deals an additional amount of 250% DMG. Also, if the target is under Bleed, this skill's DMG is increased by 50%.</span></a>
             <a href="#"><img src="images/s8.png" class="icon" id="a6"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Hunter's Instinct - 40 - CD: 2 turns</h2><br>Increases Critical DMG by 120% for 3 turns and Critical Rate until the next Crit Hit by 30% and mark the enemy with Hunter's Mark.</span></a>
             <a href="#"><img src="images/p2.png" class="icon" id="p2"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(114, 158, 56); font-size: 27px;">Forest's Favor - Passive</h2><br>After Hunter's Mark is removed, heals self by 50% of Max HP.</span></a>
@@ -382,10 +372,10 @@
             </ul>
             <ul id="skillactive3">
                 <img src="images/paladin.png" style="width: 60px;">
-                <a href="#"><img src="images/s9.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Righteousness- Basic Attack</h2><br>Deals 120% DMG (+240) to the target and decreases its ATK by 20% for 2 turns and mark it with a Light mark. Restores 10~20 energy.</span></a>
-            <a href="#"><img src="images/s10.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Rectitude - 30 - CD: 1 turn</h2><br>Deals 140% DMG (+300) to the target and marks it with a Light mark. Also, increases self DEF by 30% for 2 turns.</span></a>
-            <a href="#"><img src="images/s11.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Judgment - 60 - CD: 3 turns</h2><br>Deals 330% DMG (+1315) to the target. For each Light mark on the target, deals an additional 100% of DEF as DMG and removes all Light marks.</span></a>
-            <a href="#"><img src="images/s12.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Honor - 40 - CD: 2 turns</h2><br>Deals 160% DMG (+500) and another 250% of DEF as DMG if more than 5 Light Marks are present. After use, removes 2 Light Marks. After that, grants a shield of 50% of his Max HP.</span></a>
+                <a href="#"><img src="images/s9.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Righteous Strike- Basic Attack</h2><br>Deals 120% DMG (+240) to the target and decreases its ATK by 20% for 2 turns and mark it with a Light mark. Restores 10~20 energy.</span></a>
+            <a href="#"><img src="images/s10.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Shield of Faith - 30 - CD: 1 turn</h2><br>Deals 140% DMG (+300) to the target and marks it with a Light mark. Also, increases self DEF by 30% for 2 turns.</span></a>
+            <a href="#"><img src="images/s11.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Divine Judgment - 60 - CD: 3 turns</h2><br>Deals 330% DMG (+1315) to the target. For each Light mark on the target, deals an additional 100% of DEF as DMG and removes all Light marks.</span></a>
+            <a href="#"><img src="images/s12.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Sacred Oath - 40 - CD: 2 turns</h2><br>Deals 160% DMG (+500) and another 250% of DEF as DMG if more than 5 Light Marks are present. After use, removes 2 Light Marks. After that, grants a shield of 50% of his Max HP.</span></a>
             <a href="#"><img src="images/p3.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(199, 154, 71); font-size: 27px;">Grace - Passive</h2><br>Each Lightmark removed restores 5~10 Energy.</span></a>
             <img src="images/paladin.png" style="width: 60px;">
             </ul>
@@ -400,26 +390,26 @@
             </ul>
             <ul id="skillactive5">
                 <img src="images/bloodknight.png" style="width: 60px;">
-                <a href="#"><img src="images/s17.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Blood Embrace- Basic Attack</h2><br>Deals 120% DMG (+310) to the target. If his HP is less than 50%, gain 1 Blood Sigil. Restores 10~13 Energy.</span></a>
-                <a href="#"><img src="images/s18.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Rosemary's Gift - 30 - CD: 1 turn</h2><br>Deals 160% DMG (+670) to the target. Deals an additional amount of 10% of his loss HP as DMG. Gain 2 Blood Sigils.</span></a>
-                <a href="#"><img src="images/s19.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Ichor Retaliation - 70 - CD: 4 turns</h2><br>Deals 350% DMG (+1200) to the target. For each Blood Sigil, deals an additional of 25% DMG and 2% of Max HP. Removes all Blood Sigils after that. For each removed Blood Sigil, grants a shield of 2% of his Max HP.</span></a>
+                <a href="#"><img src="images/s17.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Crimson Embrace- Basic Attack</h2><br>Deals 120% DMG (+310) to the target. If his HP is less than 50%, gain 1 Blood Sigil. Restores 10~13 Energy.</span></a>
+                <a href="#"><img src="images/s18.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Vampiric Gift - 30 - CD: 1 turn</h2><br>Deals 160% DMG (+670) to the target. Deals an additional amount of 10% of his loss HP as DMG. Gain 2 Blood Sigils.</span></a>
+                <a href="#"><img src="images/s19.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Ichor Reprisal - 70 - CD: 4 turns</h2><br>Deals 350% DMG (+1200) to the target. For each Blood Sigil, deals an additional of 25% DMG and 2% of Max HP. Removes all Blood Sigils after that. For each removed Blood Sigil, grants a shield of 2% of his Max HP.</span></a>
                 <a href="#"><img src="images/s20.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Crimson Vitality - 60 - CD: 3 turns</h2><br>Increases his Max HP by 30% for 3 turns. Also, grants a shield of 30% of his lost HP.</span></a>
                 <a href="#"><img src="images/p5.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(156, 52, 52); font-size: 27px;">Hardened Will - Passive</h2><br>Each Blood Sigil will decrease his incoming DMG by 2% (up to 20%) and increases his DMG by 3% (up to 30%).</span></a>
                 <img src="images/bloodknight.png" style="width: 60px;">
             </ul>
             <ul id="skillactive6">
                 <img src="images/swordsinger.png" style="width: 60px;">
-            <a href="#"><img src="images/s21.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(197, 109, 26); font-size: 27px;">Sacred Anthems- Basic Attack</h2><br>Deals 100% DMG (+230) to the target. Applies 2 random Holy Debuffs from this list:<br>- Purity: decreases ATK by 4%.<br>- Justice: decreases DEF by 4%.<br>- Faith: increases incoming DMG by 2%.<br>Each debuff can stack up to 10 times. Also restores 15 Energy.</span></a>
             <a href="#"><img src="images/s22.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(197, 109, 26); font-size: 27px;">Revered Presence - 40 - CD: 2 turns</h2><br>Heals for 3040% of ATK + 30% of lost HP. Over-healed amount will be converted into Holy Shield.</span></a>
-            <a href="#"><img src="images/s23.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(197, 109, 26); font-size: 27px;">Divine Chant - 80 - CD: 3 turns</h2><br>Deals 400% DMG (+1515) to the target and removes all debuffs. For each removed debuff, deals an additional of 100% DMG.</span></a>
+            <a href="#"><img src="images/s21.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(197, 109, 26); font-size: 27px;">Sacred Anthem- Basic Attack</h2><br>Deals 100% DMG (+230) to the target. Applies 2 random Holy Debuffs from this list:<br>- Purity: decreases ATK by 4%.<br>- Justice: decreases DEF by 4%.<br>- Faith: increases incoming DMG by 2%.<br>Each debuff can stack up to 10 times. Also restores 15 Energy.</span></a>
+            <a href="#"><img src="images/s23.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(197, 109, 26); font-size: 27px;">Holy Chant - 80 - CD: 3 turns</h2><br>Deals 400% DMG (+1515) to the target and removes all debuffs. For each removed debuff, deals an additional of 100% DMG.</span></a>
             <a href="#"><img src="images/s24.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(197, 109, 26); font-size: 27px;">Transcendent Hymn - 50 - CD: 3 turns</h2><br>Stuns the target for 2 turns and after that, provides a Reflect buff that reflects 50% of received DMG for 3 turns.</span></a>
             <a href="#"><img src="images/p6.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(197, 109, 26); font-size: 27px;">Divine Soprano - Passive</h2><br>When total debuffs reach more than 20, total DMG received by the target increases by 30%.</span></a>
             <img src="images/swordsinger.png" style="width: 60px;">
             </ul>
             <ul id="skillactive7">
                 <img src="images/cryomancer.png" style="width: 60px;">
-                <a href="#"><img src="images/s29.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Frosty Crown- Basic Attack</h2><br>Deals <span class="elemental">120% DMG (+310)</span> to the target. Applies 1 Frost debuff. Each Frost Debuff increases target's Incoming DMG by 10%, stacks 3 times. Also, restores 15 Energy.</span></a>
-                    <a href="#"><img src="images/s30.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Frigid Mind - 40 - CD: 3 turns</h2><br>Deals <span class="elemental">220% DMG (+570)</span> to the target. For each Frost debuff, applies Frozen state to the target for 1 turn. In Frozen state, the target cannot act.</span></a>
+                <a href="#"><img src="images/s29.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Frost Crown- Basic Attack</h2><br>Deals <span class="elemental">120% DMG (+310)</span> to the target. Applies 1 Frost debuff. Each Frost Debuff increases target's Incoming DMG by 10%, stacks 3 times. Also, restores 15 Energy.</span></a>
+                    <a href="#"><img src="images/s30.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Frozen Mind - 40 - CD: 3 turns</h2><br>Deals <span class="elemental">220% DMG (+570)</span> to the target. For each Frost debuff, applies Frozen state to the target for 1 turn. In Frozen state, the target cannot act.</span></a>
                     <a href="#"><img src="images/s31.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Icy Heart - 80 - CD: 5 turns</h2><br>Deals <span class="elemental">230% DMG (+1800)</span> to the target. If the target is Frozen, removes Frozen state and all Frost debuffs and increases this skill's DMG by 40% for each removed debuff.</span></a>
                     <a href="#"><img src="images/s32.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Glacial Aura - 40 - CD: 3 turns</h2><br>Gives a shield of 50% of her Max HP and heal herself of 30% of Max HP. Under the shield, she takes 30% less DMG and deals 20% more DMG.</span></a>
                     <a href="#"><img src="images/p7.png" class="icon"><span class="tooltip"><h2 class="flavortextminus" style="color: rgb(27, 159, 168); font-size: 27px;">Everwinter Gaze - Passive</h2><br>DMG dealt to targets under Frozen state is increases by 40%.</span></a>

--- a/script.js
+++ b/script.js
@@ -111,6 +111,9 @@ let frozenicon = document.getElementById("frozenicon");
 /* character and skill stats */
 let skill;
 let playerLevel = 1;
+let artifactLevel = 1;
+const artifactBaseBuffs = { gluttony: 6, envy: 10, pride: 10, sloth: 8, wrath: 6, greed: 10 };
+let artifactBonuses = { elemental: 0, crit: 0, reduction: 0, lifesteal: 0, physical: 0, heal: 0 };
 let skillcd = [0,0,0,0,0]
 let energy = 0;
 let energyCon = 0;
@@ -237,7 +240,7 @@ let switchClass = (playerClassName) => {
             document.getElementById("char1").style.top = "172px";
             document.getElementById("char1").style.right = "15px";
             switchButtonDefault.setAttribute("id","archerclass");
-            switchButtonDefault.innerHTML = "Mech Archer";
+            switchButtonDefault.innerHTML = "Elven Ranger";
             document.getElementById("playerHealth").setAttribute("max","8000");
             document.getElementById("playerHealth").setAttribute("value","8000");
             playerClass = 'archer';
@@ -269,7 +272,7 @@ let switchClass = (playerClassName) => {
             document.getElementById("char1").style.top = "201px";
             document.getElementById("char1").style.right = "166px";
             switchButtonDefault.setAttribute("id","mageclass");
-            switchButtonDefault.innerHTML = "Elemental Mage";
+            switchButtonDefault.innerHTML = "Arcane Sorcerer";
             document.getElementById("playerHealth").setAttribute("max","10000");
             document.getElementById("playerHealth").setAttribute("value","10000");
             playerClass = "mage";
@@ -301,7 +304,7 @@ let switchClass = (playerClassName) => {
             document.getElementById("char1").style.top = "143px";
             document.getElementById("char1").style.right = "11px";
             switchButtonDefault.setAttribute("id","paladinclass");
-            switchButtonDefault.innerHTML = "Paladin of Light";
+            switchButtonDefault.innerHTML = "Holy Paladin";
             document.getElementById("playerHealth").setAttribute("max","12000");
             document.getElementById("playerHealth").setAttribute("value","12000");
             playerClass = "paladin";
@@ -365,7 +368,7 @@ let switchClass = (playerClassName) => {
             document.getElementById("char1").style.top = "164px";
             document.getElementById("char1").style.right = "115px";
             switchButtonDefault.setAttribute("id","knightclass");
-            switchButtonDefault.innerHTML = "Blood Knight";
+            switchButtonDefault.innerHTML = "Crimson Knight";
             document.getElementById("playerHealth").setAttribute("max","15000");
             document.getElementById("playerHealth").setAttribute("value","15000");
             playerClass = "knight";
@@ -397,7 +400,7 @@ let switchClass = (playerClassName) => {
             document.getElementById("char1").style.top = "133px";
             document.getElementById("char1").style.right = "32px";
             switchButtonDefault.setAttribute("id","swordsingerclass");
-            switchButtonDefault.innerHTML = "Divine Swordsinger";
+            switchButtonDefault.innerHTML = "Celestial Swordsinger";
             document.getElementById("playerHealth").setAttribute("max","11000");
             document.getElementById("playerHealth").setAttribute("value","11000");
             playerClass = "swordsinger";
@@ -429,7 +432,7 @@ let switchClass = (playerClassName) => {
             document.getElementById("char1").style.top = "122px";
             document.getElementById("char1").style.right = "13px";
             switchButtonDefault.setAttribute("id","cryomancerclass");
-            switchButtonDefault.innerHTML = "Cryomancy Empress";
+            switchButtonDefault.innerHTML = "Frost Empress";
             document.getElementById("playerHealth").setAttribute("max","12000");
             document.getElementById("playerHealth").setAttribute("value","12000");
             playerClass = "cryomancer";
@@ -478,6 +481,7 @@ statslvl = [1,1,1,1];
     cooldown = 0;
     eleDMG = 0;
     phyDMG = 0;
+    updateArtifacts();
     energyCon = 0;
     holyshieldcooldown = 0;
     dragonMaxHP = 5000;
@@ -676,6 +680,7 @@ let LevelUp = (statstype) => {
     document.getElementById("playerLvl").innerHTML = "Level "+playerLevel;
     document.getElementById("message").style.pointerEvents = "auto";
     lvlupPanel.classList.remove('show');
+    updateArtifacts();
 }
 
 
@@ -930,6 +935,7 @@ let castSupport = (supportSkill) => {
 }
 
 let healSkill = (healing) => {
+    healing = healing + healing*artifactBonuses.heal;
     if (healBuff == true) {
         healing = healing + healing*0.5;
         playerHP = playerHP + healing;
@@ -954,6 +960,7 @@ let healSkill = (healing) => {
 }
 
 let holyHealSkill = (holyhealing) => {
+    holyhealing = holyhealing + holyhealing*artifactBonuses.heal;
     if (healBuff == true) {
         holyhealing = holyhealing + holyhealing*0.5;
         playerHP = playerHP + holyhealing;
@@ -1425,9 +1432,11 @@ let castMagic = (skill) =>  {
             if (skillcd[3] > 0) {
                 document.getElementById("a3").style.opacity = 1;
             }
-            
-           
-               
+
+            eleDMG += eleDMG * artifactBonuses.elemental;
+            phyDMG += phyDMG * artifactBonuses.physical;
+            critRate = defaultCrit + artifactBonuses.crit;
+
             //raw damage calculation
             if (debuffAmount >= 20) {
                 totaldebuffmodifier = 0.3;
@@ -1458,11 +1467,17 @@ let castMagic = (skill) =>  {
             if (dmgreceive == true) {
                 damagePlayer = damagePlayer + damagePlayer*0.3 + damagePlayer*doublemodifier + damagePlayer*hunteratkmodifier + damagePlayer*0.03*bloodsigil - dragonDEF*dragonDEFmodifier + damagePlayer*0.02*hd[2] + damagePlayer*totaldebuffmodifier + damagePlayer*frozenmodifier + damagePlayer*frostmodifier + damagePlayer*glacialdmgupmod;
                 dragonHP -= damagePlayer.toFixed(0);
-                 dmgreceive = false;
+                playerHP = Math.min(playerHP + damagePlayer*artifactBonuses.lifesteal, playerMaxHP);
+                playerHealthText.innerHTML = parseInt(playerHP);
+                playerHealth.value = playerHP;
+                dmgreceive = false;
                 dmgReceiveIcon.style.display = "none";
             } else {
                 damagePlayer = damagePlayer + damagePlayer*doublemodifier + damagePlayer*hunteratkmodifier + damagePlayer*0.03*bloodsigil - dragonDEF*dragonDEFmodifier + damagePlayer*0.02*hd[2] + damagePlayer*totaldebuffmodifier+damagePlayer*frozenmodifier + damagePlayer*frostmodifier + damagePlayer*glacialdmgupmod;
                 dragonHP -= damagePlayer.toFixed(0);
+                playerHP = Math.min(playerHP + damagePlayer*artifactBonuses.lifesteal, playerMaxHP);
+                playerHealthText.innerHTML = parseInt(playerHP);
+                playerHealth.value = playerHP;
                
             }
  
@@ -1898,7 +1913,7 @@ let castMagic = (skill) =>  {
         //damage
         if (shieldState == false) {
             damageDragon = dragonATK + random(300, 500) - playerDEF;
-            damageDragon = damageDragon - damageDragon*0.02*bloodsigil - damageDragon*glacialdmgdownmod;
+            damageDragon = damageDragon - damageDragon*0.02*bloodsigil - damageDragon*glacialdmgdownmod - damageDragon*artifactBonuses.reduction;
         } else {
             damageDragon = 0;
             shieldState = false;
@@ -2178,13 +2193,33 @@ function openCat(evt, catName) {
     evt.currentTarget.className += " active";
   }
 
+function updateArtifacts() {
+    artifactLevel = playerLevel;
+    document.getElementById("artifactLevel").innerText = artifactLevel;
+    document.getElementById("gluttonyBuff").innerText = artifactBaseBuffs.gluttony + (artifactLevel - 1);
+    document.getElementById("envyBuff").innerText = artifactBaseBuffs.envy + (artifactLevel - 1);
+    document.getElementById("prideBuff").innerText = artifactBaseBuffs.pride + (artifactLevel - 1);
+    document.getElementById("slothBuff").innerText = artifactBaseBuffs.sloth + (artifactLevel - 1);
+    document.getElementById("wrathBuff").innerText = artifactBaseBuffs.wrath + (artifactLevel - 1);
+    document.getElementById("greedBuff").innerText = artifactBaseBuffs.greed + (artifactLevel - 1);
+
+    artifactBonuses.elemental = (artifactBaseBuffs.gluttony + (artifactLevel - 1)) / 100;
+    artifactBonuses.crit = artifactBaseBuffs.envy + (artifactLevel - 1);
+    artifactBonuses.reduction = (artifactBaseBuffs.pride + (artifactLevel - 1)) / 100;
+    artifactBonuses.lifesteal = (artifactBaseBuffs.sloth + (artifactLevel - 1)) / 100;
+    artifactBonuses.physical = (artifactBaseBuffs.wrath + (artifactLevel - 1)) / 100;
+    artifactBonuses.heal = (artifactBaseBuffs.greed + (artifactLevel - 1)) / 100;
+    critRate = defaultCrit + artifactBonuses.crit;
+    playerCritText.innerHTML = critRate + "%";
+}
+
 
 
 function mageSkill(skill) {
     //define the skill consumption
     switch (skill) {
        case "icebolt":
-               skillName = "Icebolt";
+               skillName = "Frost Bolt";
                energyCon = 0;
            break;
        case "rainoffire":
@@ -2193,7 +2228,7 @@ function mageSkill(skill) {
             err.id = 'cooldown';
             throw err;
            } else {
-           skillName = "Rain of Fire";
+           skillName = "Flamestrike";
            energyCon = 30;
            }
            break;
@@ -2203,7 +2238,7 @@ function mageSkill(skill) {
             err.id = 'cooldown';
             throw err;
            } else {
-           skillName = "Thunderstorm";
+           skillName = "Arcane Tempest";
            energyCon = 60;
            }
            break;
@@ -2213,7 +2248,7 @@ function mageSkill(skill) {
             err.id = 'cooldown';
             throw err;
            } else {
-           skillName = "Bane of Death";
+           skillName = "Curse of Decay";
            energyCon = 25;
            }
            break;
@@ -2227,7 +2262,7 @@ function mageSkill(skill) {
 function archerSkill (skill) {
     switch (skill) {
             case "arrowoflight":
-                skillName = "Arrow of Light";
+                skillName = "Radiant Arrow";
                 energyCon = 0;
                 break;
             case "bloodshed":
@@ -2236,7 +2271,7 @@ function archerSkill (skill) {
             err.id = 'cooldown';
             throw err;
                 } else {
-                skillName = "Bloodshed";
+                skillName = "Crimson Volley";
                 energyCon = 35;
                 }
                 break;
@@ -2270,7 +2305,7 @@ function paladinSkill(skill) {
     
     case "righteousness":
                 
-    skillName = "Righteousness";
+    skillName = "Righteous Strike";
     energyCon = 0;
     break;
 case "rectitude":
@@ -2279,7 +2314,7 @@ case "rectitude":
             err.id = 'cooldown';
             throw err;
     } else {
-    skillName = "Rectitude";
+    skillName = "Shield of Faith";
     energyCon = 30;
     }
     break;
@@ -2289,7 +2324,7 @@ case "judgment":
             err.id = 'cooldown';
             throw err;
     } else {
-    skillName = "Judgment";
+    skillName = "Divine Judgment";
     energyCon = 60;
     }
     break;
@@ -2299,7 +2334,7 @@ case "honor":
             err.id = 'cooldown';
             throw err;
     } else {
-    skillName = "Honor";
+    skillName = "Sacred Oath";
     energyCon = 40;
     }
     break;
@@ -2354,7 +2389,7 @@ function necroSkill(skill) {
 function knightSkill(skill) {
     switch (skill) {
         case "bloodembrace":
-            skillName = "Blood Embrace";
+        skillName = "Crimson Embrace";
             energyCon = 0;
             break;
         case "rosemarysgift":
@@ -2363,7 +2398,7 @@ function knightSkill(skill) {
             err.id = 'cooldown';
             throw err;
             } else {
-            skillName = "Rosemary's Gift";
+        skillName = "Vampiric Gift";
             energyCon = 30;
             }
             break;
@@ -2373,7 +2408,7 @@ function knightSkill(skill) {
             err.id = 'cooldown';
             throw err;
             } else {
-            skillName = "Ichor Retaliation";
+        skillName = "Ichor Reprisal";
             energyCon = 70;
             }
             break;
@@ -2395,7 +2430,7 @@ function knightSkill(skill) {
 function swordsingerSkill(skill) {
     switch (skill) {
         case "sacredanthems":
-                skillName = "Sacred Anthems";
+                skillName = "Sacred Anthem";
                 energyCon = 0;
                 break;
             case "reveredpresence":
@@ -2414,7 +2449,7 @@ function swordsingerSkill(skill) {
             err.id = 'cooldown';
             throw err;
                 } else {
-                skillName = "Divine Chant";
+                skillName = "Holy Chant";
                 energyCon = 80;
                 }
                 break;
@@ -2437,7 +2472,7 @@ function swordsingerSkill(skill) {
 function cryomancerSkill(skill) {
     switch (skill) {
             case "frostycrown":
-                skillName = "Frosty Crown";
+                skillName = "Frost Crown";
                 energyCon = 0;
                 break;
             case "frigidmind":
@@ -2446,7 +2481,7 @@ function cryomancerSkill(skill) {
             err.id = 'cooldown';
             throw err;
                 } else {
-                skillName = "Frigid Mind";
+                skillName = "Frozen Mind";
                 energyCon = 40;
                 }
                 break;

--- a/style.css
+++ b/style.css
@@ -44,7 +44,7 @@ body {
     justify-content: center;
 	height: 80px;
 	margin: auto;
-	width: 1106px;
+        width: 1400px;
 	bottom: -700px;
 	border-radius: 15px;
 	background-color: #000000c5;
@@ -633,7 +633,7 @@ progress#dragonHealth {
 }
 #container {
 	position: absolute;
-	width: 1300px;
+        width: 1600px;
 	margin: 0 auto;
 }
 #bookimg {
@@ -732,7 +732,7 @@ h5 {
      url("images/background.png");
 	background-size: cover;
 	background-position: center center;
-	width: 1300px;
+        width: 1600px;
 	height: 760px;
 	margin: 15px auto;
 	box-sizing: border-box;


### PR DESCRIPTION
## Summary
- Expand battle arena width for a wider play area
- Remove unused shop tabs and add dynamic, level-scaling artifacts
- Rename characters and skills to fit a high-fantasy theme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897455e6e5883298fad02099e35b05d