### PR TITLE
Fix overlay alignment and level-up attack

### DIFF
--- a/script.js
+++ b/script.js
@@ -46,6 +46,20 @@ let effectInterval;
 /* custom function */
 const random = (min, max) => Math.floor(Math.random() * (max - min)) + min;
 
+const positionDamageText = (target) => {
+  const rect = target.getBoundingClientRect();
+  const dmgElem = document.getElementById("playerdmgtext");
+  dmgElem.style.left = rect.left + rect.width / 2 - dmgElem.offsetWidth / 2 + "px";
+};
+
+const positionRhombuses = () => {
+  const char = document.getElementById("char1");
+  const rect = char.getBoundingClientRect();
+  const icy = document.getElementById("icyglass");
+  icy.style.left = rect.left + rect.width / 2 - 80 + "px";
+  icy.style.top = rect.top + rect.height / 2 - 80 + "px";
+};
+
 
 /* texts, graphics and buttons */
 let dragonHealthText = document.querySelector("h4");
@@ -422,6 +436,7 @@ let switchClass = (playerClassName) => {
             document.getElementById("char1").style.width = "548px";
             document.getElementById("char1").style.top = "122px";
             document.getElementById("char1").style.right = "13px";
+            positionRhombuses();
             switchButtonDefault.setAttribute("id","cryomancerclass");
             switchButtonDefault.innerHTML = "Frost Empress";
             document.getElementById("playerHealth").setAttribute("max","12000");
@@ -621,7 +636,7 @@ let LevelUp = (statstype) => {
     switch (statstype) {
         case "atk":
             statslvl[0]++;
-            playerdefaultatk = playerdefaultatk + playerdefaultatk*0.02*statslvl[0];
+            playerdefaultatk *= 1.02;
             playerATK = playerdefaultatk;
             playerAtkText.innerHTML = parseInt(playerATK);
             atklvlText.innerHTML = "Lvl. "+statslvl[0];
@@ -672,6 +687,7 @@ let LevelUp = (statstype) => {
     document.getElementById("message").style.pointerEvents = "auto";
     lvlupPanel.classList.remove('show');
     updateArtifacts();
+    playerAtkText.innerHTML = parseInt(playerATK);
 }
 
 
@@ -1820,23 +1836,24 @@ let castMagic = (skill) =>  {
             document.getElementById("lightnumber").innerHTML = lightmark;
             let totalDot = bleedDot + poisonDot;
             
+            const dmgElem = document.getElementById("playerdmgtext");
             if (critHit == false) {
-                document.getElementById("playerdmgtext").innerHTML = damagePlayer.toFixed(0);
-                document.getElementById("playerdmgtext").style.display = "block";
-                document.getElementById("playerdmgtext").style.left = "311px";
-                setTimeout(()=>{document.getElementById("playerdmgtext").style.opacity = 0}, 1000);
-                document.getElementById("playerdmgtext").style.opacity = 1;
+                dmgElem.innerHTML = damagePlayer.toFixed(0);
+                dmgElem.style.display = "block";
+                positionDamageText(document.getElementById("dragon"));
+                setTimeout(()=>{dmgElem.style.opacity = 0}, 1000);
+                dmgElem.style.opacity = 1;
                 logmessage = "You did <span class='damage'>" + damagePlayer.toFixed(0) + " (+" +totalDot.toFixed(0)+ " DoT DMG)</span> DMG on the dragon by using <span class='damage'>" + skillName + "</span>.";
-                
-                
+
+
             } else {
-                document.getElementById("playerdmgtext").innerHTML = "CRIT<br>" + damagePlayer.toFixed(0);
-                document.getElementById("playerdmgtext").style.display = "block";
-                document.getElementById("playerdmgtext").style.left = "311px";
-                setTimeout(()=>{document.getElementById("playerdmgtext").style.opacity = 0}, 1000);
-                document.getElementById("playerdmgtext").style.opacity = 1;
+                dmgElem.innerHTML = "CRIT<br>" + damagePlayer.toFixed(0);
+                dmgElem.style.display = "block";
+                positionDamageText(document.getElementById("dragon"));
+                setTimeout(()=>{dmgElem.style.opacity = 0}, 1000);
+                dmgElem.style.opacity = 1;
                 logmessage = "You did a <span class='damage'>Critical DMG</span> of <span class='damage'>" + damagePlayer.toFixed(0) + " (+" +totalDot.toFixed(0)+ " DoT DMG)</span> on the dragon by using <span class='damage'>" + skillName + "</span>.";
-                
+
                 critHit=false;
 
             }
@@ -1898,11 +1915,12 @@ let castMagic = (skill) =>  {
         
      
 
-        document.getElementById("playerdmgtext").innerHTML = damageDragon.toFixed(0);
-                document.getElementById("playerdmgtext").style.display = "block";
-                document.getElementById("playerdmgtext").style.left = "849px";
-                setTimeout(()=>{document.getElementById("playerdmgtext").style.opacity = 0}, 1000);
-                document.getElementById("playerdmgtext").style.opacity = 1;
+        const dmgElem2 = document.getElementById("playerdmgtext");
+        dmgElem2.innerHTML = damageDragon.toFixed(0);
+        dmgElem2.style.display = "block";
+        positionDamageText(document.getElementById("char1"));
+        setTimeout(()=>{dmgElem2.style.opacity = 0}, 1000);
+        dmgElem2.style.opacity = 1;
         dragonHP = dragonHP - damageDragon*reflectmodifier;
         holyshieldText.innerHTML = parseInt(holyshieldamount);
         holyshieldbar.value = parseInt(holyshieldamount);

--- a/style.css
+++ b/style.css
@@ -349,17 +349,17 @@ body {
 	display: none;
 }
 #playerdmgtext {
-	z-index: 999999;
-	position: absolute;
-	display: none;
-	font-size: 70px;
-	opacity: 1;
-	transition: all 0.1s;
-	top: 413px;
-	left: 311px;
-	color: darkred;
-	font-weight: bold;
-	text-shadow: 0px 0px 0 #fff, -5px 0 0 #fff, 0 5px 0 #fff, 0 -5px 0 #fff, 5px 5px #fff, -5px -5px 0 #fff, 5px -5px 0 #fff, -5px 5px 0 #fff;
+        z-index: 999999;
+        position: absolute;
+        display: none;
+        font-size: 70px;
+        opacity: 1;
+        transition: all 0.1s;
+        top: 413px;
+        left: 0;
+        color: darkred;
+        font-weight: bold;
+        text-shadow: 0px 0px 0 #fff, -5px 0 0 #fff, 0 5px 0 #fff, 0 -5px 0 #fff, 5px 5px #fff, -5px -5px 0 #fff, 5px -5px 0 #fff, -5px 5px 0 #fff;
 }
 #phoenixdmgtext {
 	z-index: 999999;
@@ -811,12 +811,25 @@ p {
 	text-align: center;
 }
 span {
-	background-color: #ffffff00;
-	color: #d94f45;
-	font-size: 16px;
-	padding: 1px 10px;
-	font-weight: 700;
-	line-height: 2em;
+        background-color: #ffffff00;
+        color: #d94f45;
+        font-size: 16px;
+        padding: 1px 10px;
+        font-weight: 700;
+        line-height: 2em;
+}
+.tooltip {
+        display: none;
+        position: absolute;
+        background-color: rgba(0, 0, 0, 0.8);
+        color: #ffffff;
+        padding: 10px;
+        border-radius: 10px;
+        box-shadow: 0 0 10px rgba(0,0,0,0.5);
+        z-index: 10;
+}
+a:hover .tooltip {
+        display: block;
 }
 .damage {
 	color: rgb(255, 135, 135);
@@ -1017,18 +1030,18 @@ li {
 
 
   .rhombus {
-	  background: linear-gradient(rgba(245, 245, 245, 0.1), rgba(245, 245, 245, 0.1)), rgba(255, 255, 255, 0.1) no-repeat center center fixed;
-	background-size: cover;
-	width: 160px;
-	height: 160px;
-	transform: rotate(45deg);
-	position: relative;
-	top: 35px;
-	left: 879px;
-	animation: freeze 1s infinite;
-	border: 2px solid #c2d6d6;
-	box-sizing: border-box;
-	box-shadow: 0 0 10px #c2d6d6;
+          background: linear-gradient(rgba(245, 245, 245, 0.1), rgba(245, 245, 245, 0.1)), rgba(255, 255, 255, 0.1) no-repeat center center fixed;
+        background-size: cover;
+        width: 160px;
+        height: 160px;
+        transform: rotate(45deg);
+        position: absolute;
+        top: 0;
+        left: 0;
+        animation: freeze 1s infinite;
+        border: 2px solid #c2d6d6;
+        box-sizing: border-box;
+        box-shadow: 0 0 10px #c2d6d6;
   }
   
   @keyframes freeze {
@@ -1039,21 +1052,20 @@ li {
   }
   
   #rhombus2 {
-	   width: 100px;
-	height: 100px;
-	  top: 63px;
-	  left: 865px;
-	  z-index: 4;
+           width: 100px;
+        height: 100px;
+          top: 30px;
+          left: 30px;
+          z-index: 4;
   }
   #rhombus3 {
-	   width: 50px;
-	height: 50px;
-	  top: -44px;
-	  left: 985px;
+           width: 50px;
+        height: 50px;
+          top: 55px;
+          left: 55px;
   }
   
   #icyglass {
-	position: absolute;
-	display: none;
-	position: absolute;
+        position: absolute;
+        display: none;
   }


### PR DESCRIPTION
## Summary
- center damage numbers and rhombus overlays relative to characters
- correct ATK Up level-up to increase attack instead of crit
- hide artifact tooltip numbers until hover

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689752086e80832993400b5a82455f2d